### PR TITLE
refactor: Changed relapse and update commands to do channel checks natively

### DIFF
--- a/cogs/streak.py
+++ b/cogs/streak.py
@@ -11,14 +11,9 @@ class streak(commands.Cog):
         self.client = client
 
     @commands.command(name="relapse")
+    @commands.check(utils.is_in_streak_channel)
     @commands.cooldown(3, 300, commands.BucketType.user)
     async def relapse(self, ctx,  *, declared_streak_length:utils.TimeConverter=0.0):
-
-        #Make sure its in the streak channel (this isnt the right way to do it, ill figure out the right way at a later date)
-        guild_data = await database.database_conn.select_guild_data(ctx.guild.id)
-        if guild_data:
-            if guild_data[2] != ctx.channel.id:
-                return
 
         #Decode the arguments to get current starting date
         if not declared_streak_length:
@@ -54,15 +49,10 @@ class streak(commands.Cog):
             await ctx.send("This is your first sreak on record, good luck")
 
     @commands.command(name="update")
+    @commands.check(utils.is_in_streak_channel)
     @commands.cooldown(3, 900, commands.BucketType.user)
     async def update(self, ctx):
 
-        #Make sure its in the streak channel (this isnt the right way to do it, ill figure out the right way at a later date)
-        guild_data = await database.database_conn.select_guild_data(ctx.guild.id)
-        if guild_data:
-            if guild_data[2] != ctx.channel.id:
-                return
-        
         ## Previous streak data
         userdata = await database.database_conn.seclect_user_data(ctx.author.id)
         previous = True if userdata else False

--- a/utils.py
+++ b/utils.py
@@ -28,6 +28,12 @@ class TimeConverter(commands.Converter):
             time += unit * int(part[0])
         return time
 
+async def is_in_streak_channel(ctx):
+    guild_data = await database.database_conn.select_guild_data(ctx.guild.id)
+    if guild_data[1] != 1:
+        return True
+    return guild_data[2] == ctx.channel.id
+
 def extract_json():
     file_ = open("settings.json")
     return json.load(file_)


### PR DESCRIPTION
Changed the relapse and update commands to do channel checks natively using the discord.py wrapper. Now inside the decorators of the commands, there is an additional decorator that leverages a function in the utils file to check if the server has a channel limit, and if it does make sure messages are being sent in the correct channel.

addresses issue #4 