### PR TITLE
feat: Swaped out old help command with new one that links to the wiki

### DIFF
--- a/cogs/meta.py
+++ b/cogs/meta.py
@@ -10,6 +10,7 @@ class Meta(commands.Cog):
     def __init__(self, client):
         LOGGER.warning(f"initilised {__class__.__cog_name__} cog")
         self.client = client
+        self.client.remove_command('help')
         self.status = cycle(["Hi, im ricky!"])
         self.activity_cycle.start()
 
@@ -28,6 +29,10 @@ class Meta(commands.Cog):
         bot_invite = utils.extract_json(
         )["discord_api_settings"]["invite_link"]
         await ctx.send(bot_invite)
+
+    @commands.command(name="help")
+    async def help(self, ctx):
+        await ctx.send("https://github.com/eddiebquinn/Ricky/wiki/Bot-commands")
 
 
 def setup(client):


### PR DESCRIPTION
Removed default help command and replaced it with link to bot commands wiki page. This wiki page may hopefully be able to auto generated in the future, but for now it is manually written