### PR TITLE
fix: FIxed relapses ability to handle non tuple args

### DIFF
--- a/cogs/streak.py
+++ b/cogs/streak.py
@@ -16,7 +16,7 @@ class Streak(commands.Cog):
     @commands.command(name="relapse")
     @commands.check(utils.is_in_streak_channel)
     @commands.cooldown(3, 300, commands.BucketType.user)
-    async def relapse(self, ctx,  *, declared_streak_length: utils.TimeConverter = 0.0):
+    async def relapse(self, ctx,  *, declared_streak_length: utils.TimeConverter = (0.0, False)):
         """Updated the users roles and databse entry with most recent relaspe, and posts message
 
         Args:

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -40,7 +40,7 @@ class TimeConverter(commands.Converter):
                 return False
             unit = time_dict[part[1]]
             time += unit * int(part[0])
-        return (time, overide)
+        return (float(time), overide)
 
 
 async def is_in_streak_channel(ctx):


### PR DESCRIPTION
Fixed relapses ability to handle non tuple args, this required making sure the time was set to a float when transfered and ensureing the default response was set to a tuple of a simmilar layout

Closes #31